### PR TITLE
feat: Add beta feature to restore original thumbnails

### DIFF
--- a/app/pages/popup.html
+++ b/app/pages/popup.html
@@ -274,6 +274,10 @@
             <input id="notification-checkbox" type="checkbox" checked />
           </div>
           <div class="option">
+            <span>BETA: Restore original thumbnails</span>
+            <input id="thumbnail-checkbox" type="checkbox" />
+          </div>
+          <div class="option">
             <span>Reload page automatically</span>
             <input id="reload-checkbox" type="checkbox" checked />
           </div>

--- a/app/src/background.js
+++ b/app/src/background.js
@@ -615,6 +615,9 @@ async function untranslateOtherVideos(intersectElements = null) {
           );
         }
         // End of processing for this video
+
+        // Untranslate thumbnail
+        untranslateThumbnail(video);
       }),
     );
   }
@@ -745,6 +748,9 @@ async function untranslateOtherShortsVideos(intersectElements = null) {
           );
         }
         // End of processing for this short
+
+        // Untranslate thumbnail
+        untranslateThumbnail(shortElement);
       }),
     );
   }
@@ -761,6 +767,55 @@ async function untranslateOtherShortsVideos(intersectElements = null) {
         window.YoutubeAntiTranslate.ALL_ARRAYS_SHORTS_SELECTOR,
       ),
     ),
+  );
+}
+
+async function untranslateThumbnail(videoElement) {
+  chrome.storage.sync.get(
+    { untranslateThumbnail: false },
+    async function (items) {
+      if (!items.untranslateThumbnail) {
+        return;
+      }
+
+      const linkElement = videoElement.querySelector('a[href*="/watch?v="]');
+      if (!linkElement) {
+        return;
+      }
+
+      const videoId = window.YoutubeAntiTranslate.extractVideoIdFromUrl(
+        linkElement.href,
+      );
+      if (!videoId) {
+        return;
+      }
+
+      const response =
+        await window.YoutubeAntiTranslate.getVideoDataFromYoutubeI(videoId);
+      if (
+        !response ||
+        !response.data ||
+        !response.data.videoDetails ||
+        !response.data.videoDetails.thumbnail ||
+        !response.data.videoDetails.thumbnail.thumbnails
+      ) {
+        return;
+      }
+
+      const thumbnails = response.data.videoDetails.thumbnail.thumbnails;
+      if (thumbnails.length === 0) {
+        return;
+      }
+
+      const originalThumbnailUrl = thumbnails[thumbnails.length - 1].url;
+
+      const thumbnailImage = videoElement.querySelector(
+        "ytd-thumbnail yt-image > img",
+      );
+      if (thumbnailImage && thumbnailImage.src !== originalThumbnailUrl) {
+        thumbnailImage.src = originalThumbnailUrl;
+      }
+    },
   );
 }
 

--- a/app/src/global.js
+++ b/app/src/global.js
@@ -1470,6 +1470,28 @@ ytm-shorts-lockup-view-model`,
     return { response: response?.response, data: null };
   },
 
+  getVideoDataFromYoutubeI: async function (videoId) {
+    const body = {
+      context: {
+        client: {
+          clientName: this.isMobile() ? "MWEB" : "WEB",
+          clientVersion: "2.20250731.09.00",
+        },
+      },
+      videoId,
+    };
+
+    const headers = await this.getYoutubeIHeadersWithCredentials();
+
+    const response = await this.cachedRequest(
+      `https://${this.isMobile() ? "m" : "www"}.youtube.com/youtubei/v1/player?prettyPrint=false`,
+      JSON.stringify(body),
+      headers,
+    );
+
+    return response;
+  },
+
   getSAPISID: function () {
     const match = document.cookie.match(/SAPISID=([^\s;]+)/);
     return match ? match[1] : null;

--- a/app/src/options.js
+++ b/app/src/options.js
@@ -103,6 +103,7 @@ function saveOptions() {
       untranslateDescription: true,
       untranslateChannelBranding: true,
       untranslateNotification: true,
+      untranslateThumbnail: false,
       youtubeDataApiKey: null,
     },
     function (items) {
@@ -139,6 +140,7 @@ function loadOptions() {
       untranslateDescription: true,
       untranslateChannelBranding: true,
       untranslateNotification: true,
+      untranslateThumbnail: false,
       youtubeDataApiKey: null,
     },
     function (items) {
@@ -165,6 +167,8 @@ function loadOptions() {
         items.untranslateChannelBranding;
       document.getElementById("notification-checkbox").checked =
         items.untranslateNotification;
+      document.getElementById("thumbnail-checkbox").checked =
+        items.untranslateThumbnail;
       document.getElementById("api-key-input").value = items.youtubeDataApiKey;
     },
   );
@@ -184,6 +188,8 @@ function checkboxUpdate() {
       ).checked,
       untranslateNotification: document.getElementById("notification-checkbox")
         .checked,
+      untranslateThumbnail:
+        document.getElementById("thumbnail-checkbox").checked,
     },
     () => {
       reloadActiveYouTubeTab();
@@ -251,6 +257,9 @@ function addListeners() {
     .addEventListener("click", checkboxUpdate);
   document
     .getElementById("notification-checkbox")
+    .addEventListener("click", checkboxUpdate);
+  document
+    .getElementById("thumbnail-checkbox")
     .addEventListener("click", checkboxUpdate);
   document
     .getElementById("save-api-key-button")


### PR DESCRIPTION
This commit introduces a new, optional feature to restore original video thumbnails, preventing YouTube from showing localized versions.

- Adds a 'BETA: Restore original thumbnails' checkbox to the addon's options page.
- Implements the logic to fetch the original thumbnail URL from YouTube's internal `youtubei/v1/player` API.
- Updates the `src` attribute of the thumbnail images on the page to display the original thumbnail.